### PR TITLE
Fixed the incorrect CSS for the links in Resources section

### DIFF
--- a/resource.css
+++ b/resource.css
@@ -42,6 +42,8 @@ nav {
 
 a {
   font-size: 15px;
+  display: block;
+  padding: 10px;
 }
 nav a:hover {
   color: white;
@@ -146,7 +148,6 @@ footer a {
 }
 .study-card h3{
   background:white;
-  padding:5px 10px;
   color:#333;
 }
 

--- a/resource.css
+++ b/resource.css
@@ -42,8 +42,15 @@ nav {
 
 a {
   font-size: 15px;
+}
+.view{
   display: block;
   padding: 10px;
+}
+h3:hover{
+  position:relative;
+  top: -3px;
+  box-shadow: 0px 4px 5px 0px #706f6f;
 }
 nav a:hover {
   color: white;

--- a/resource.html
+++ b/resource.html
@@ -68,25 +68,25 @@
             <div class="study-base">
                 <img src="images/5.png" alt="image1">
             </div>
-            <h3><a target="_blank" href="Notes/Surface Chemistry Complete NCERT.pdf">View</a><h3>
+            <h3><a target="_blank" class="view" href="Notes/Surface Chemistry Complete NCERT.pdf">View</a><h3>
         </div>
         <div class="study-card ">
             <div class="study-base">
                 <img src="images/6.jpg" alt="image1">
             </div>
-            <h3><a target="_blank" href="Notes/Solid State New Complete Chapter Notes.pdf">View</a><h3>
+            <h3><a target="_blank" class="view" href="Notes/Solid State New Complete Chapter Notes.pdf">View</a><h3>
         </div>
         <div class="study-card ">
             <div class="study-base">
                 <img src="images/7.jpg" alt="image2">
             </div>
-            <h3><a target="_blank" href="Notes/Solid State New Complete Chapter Notes.pdf">View</a><h3>
+            <h3><a target="_blank" class="view" href="Notes/Solid State New Complete Chapter Notes.pdf">View</a><h3>
         </div>
         <div class="study-card ">
             <div class="study-base">
                 <img src="images/9.png" alt="image1">
             </div>
-            <h3><a target="_blank" href="Notes/Solid State New Complete Chapter Notes.pdf">View</a><h3>
+            <h3><a target="_blank" class="view" href="Notes/Solid State New Complete Chapter Notes.pdf">View</a><h3>
         </div>
     
 </main>


### PR DESCRIPTION
## What is the problem that is getting fixed?
Due to incorrect CSS of the links in Resources section, we can click only the text to open the link. So, I am making the whole box clickable that contains the link text.

### Before:
![image](https://user-images.githubusercontent.com/86077008/135727085-7737e272-0905-46ee-90a2-fd5b6f90490b.png)

### After:
![image](https://user-images.githubusercontent.com/86077008/135727100-801981c8-875c-499c-8bcc-a8f63cf96722.png)
