### PR TITLE
Fixed home grid of resource.html

### DIFF
--- a/resource.html
+++ b/resource.html
@@ -16,7 +16,7 @@
     <nav class="" >
         <div class="">
             <div class="grid-container">
-                <a class="grid-item " href="#">Home</a>
+                <a class="grid-item " href="./index.html">Home</a>
                 <a class="grid-item " href="#courses">Courses</a>
                 <a class="grid-item " href="#yt">Youtube Channels</a>
                 <a class="grid-item " href="#qb">Question Banks</a>


### PR DESCRIPTION
Now, when someone clicks on a home grid of resources page, they will redirect to the home page, i.e; index.html. All other grids worked except the home grid.


![image](https://user-images.githubusercontent.com/78433942/135732049-54cd8bf4-07a2-4780-99f3-aa6dfd544f2a.png)


