### PR TITLE
Fixed About and donate book page header links

### DIFF
--- a/about.html
+++ b/about.html
@@ -55,7 +55,7 @@
             <span class="sr-only">(current)</span></a>
         </li>
         <li class="nav-item">
-          <a href="#" class="nav-link active" target="_blank">
+          <a href="#" class="nav-link active" target="_blank" onclick="return false;">
             <i class="fas fa-book"></i> About
           </a>
         </li>

--- a/public/donate-book.html
+++ b/public/donate-book.html
@@ -36,7 +36,7 @@
               class="sr-only">(current)</span></a>
                  </li>
                 <li class="nav-item"><a href="../about.html" class="nav-link" target="_blank"> <i class="fas fa-book"></i> About </a></li>
-        <li class="nav-item"><a href="#" class="nav-link" target="_blank"> <i
+        <li class="nav-item"><a href="#" class="nav-link" target="_blank" onclick="return false;"> <i
               class="fas fa-book"></i> Donate Books </a></li>
         <li class="nav-item"><a href=".././resource.html" class="nav-link"> <i class="fas fa-external-link-alt"></i>
             Resources</a></li>


### PR DESCRIPTION
Fixed "About" and "donate book" page header links by hyperlinked by its own page itself. I have used Javascript intrinsic event handler "onclick" to resolve the hyperlink issue by disabling it if the link is on the same page itself.