### PR TITLE
Scroll-to-top button now not overlapping with contact us link and has an hover effect

### DIFF
--- a/assets/css/About.css
+++ b/assets/css/About.css
@@ -137,6 +137,15 @@ a.nav-link {
     display: block;
     border-radius: 10px;
     cursor: pointer;
+    margin-bottom: 200%;
+}
+
+#topBtn a:hover{
+    background-color: white;
+}
+
+#topBtn a span:hover{
+    color: black;
 }
 
 #topBtn a span {


### PR DESCRIPTION
Fixes #375 

On scrolling down:
![image](https://user-images.githubusercontent.com/71882225/136745528-1c7ee37f-4e0a-49bb-8101-80c821bd5617.png)

On scrolling down and hover:
![image](https://user-images.githubusercontent.com/71882225/136745489-900ec1d6-a586-47bc-a8a3-93382f950b1f.png)
