### PR TITLE
Made the recommeded books section responsive

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1115,20 +1115,13 @@ strong {
 }
 
 .books {
-display: flex;
+  display: flex;
   gap: 1rem;
   display: flex;
   flex-flow: row wrap;
   justify-content: space-around;
   list-style: none;
 }
-
-.books div{
-  height:500px;
-
-}
-
-
 
 .books li img {
   width: 200px;
@@ -1155,9 +1148,15 @@ display: flex;
   }
 }
 .books1{
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit,minmax(290px,1fr));
   justify-content: space-around;
 }
+
+.books1 div{
+  align-self: center;
+}
+
 .books1 img{
   margin:30px 50px;
     width:  250px;


### PR DESCRIPTION
Hey! The recommended books section was not responsive and was creating a horizontal scrollbar for screen widths less than 1400px.
Before -
![Recommeded Books section causing Horizontal ScrollBar to appear](https://user-images.githubusercontent.com/84654095/138051886-aee00b83-0706-4598-b736-344449a33858.png)

After making the changes - 
![New Recommended Books section](https://user-images.githubusercontent.com/84654095/138052040-f08aff43-b6de-449b-b954-75f82ed12c57.png)

Do comment if any changes are to be made. 
Thank you for giving us a chance to contribute.
