### PR TITLE
Improved about page navbar

### DIFF
--- a/about.html
+++ b/about.html
@@ -46,8 +46,9 @@
   </div>
 
   <!-- Navbar started -->
+  
   <nav class="navbar navbar-expand-lg navbar-dark bg-info">
-    <a class="navbar-brand ml-4" href="index.html"><img src="assets/logos/finalLogo.png" alt="AEC Library"
+    <a class="navbar-brand" href="index.html"><img src="assets/logos/finalLogo.png" alt="AEC Library"
         class="logo-img" /></a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
       aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -81,7 +82,7 @@
         </li>
         <li class="nav-item">
           <a href="./sign up page/index.html" class="nav-link" target="_blank">
-            <i class="fas fa-sign-in-alt"></i> SIGN UP
+            <i class="fas fa-sign-in-alt"></i> Sign up
           </a>
         </li>
         

--- a/assets/css/About.css
+++ b/assets/css/About.css
@@ -40,8 +40,9 @@ body {
 
 /* navbar */
 .navbar {
-    background-color: #343a40 !important;
-    box-shadow: 0px 0px 16px 9px black;
+    background-color:#6f4e37b0 !important;
+    /* box-shadow: 0px 0px 16px 9px black; */
+    
 }
 
 .navbar-nav li a:after {
@@ -80,10 +81,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-info {
     margin-left: 2rem;
 }
 
-.logo-img {
-    height: 3rem;
-    width: 3rem;
-}
+
 
 .navbar-nav li a:after {
     bottom: 0;
@@ -95,6 +93,10 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-info {
     background: #fff;
     transition: width 0.3s ease 0s, left 0.3s ease 0s;
     width: 0;
+}
+.nav-item
+{
+   padding: 0px 20px 0px 0px; 
 }
 
 .navbar-nav li a:hover:after {
@@ -471,11 +473,13 @@ footer {
     font-size: 28px;
   }
   
-  .logo-img {
-    margin-left: 40px;
+  .logo-img{
+    margin-left: 20px;
+    margin-right: 125px;
     /* Width and height same to make icon look more professional */
-    height: 3rem;
-    width: 3rem;
+    height: 3.5rem;
+    width: 3.5rem;
+   
   }
 /* Media Query */
 


### PR DESCRIPTION
Issue #537 
I have improved the navbar of about page. It is responsive and matches with the theme of the about page. Here are some screenshots of the about page's navbar.
1) Laptop view
![1](https://user-images.githubusercontent.com/77922626/152306459-aa4dfa8c-d9e8-46b3-813e-4cd5af84df43.PNG)
2) Mobile view
![2](https://user-images.githubusercontent.com/77922626/152306462-bffb1f8c-1b4b-44a5-94fc-7b6cb255de3a.PNG)
3) Mobile view
![3](https://user-images.githubusercontent.com/77922626/152307108-3eccbb20-17b6-4e64-970d-57fc317db7b8.PNG)
4) Mobile view
![4](https://user-images.githubusercontent.com/77922626/152306539-979666cf-ab49-4b20-94be-dfa52a82dbf3.PNG)
5) Mobile view
![5](https://user-images.githubusercontent.com/77922626/152306540-f5ad0fda-d1fc-48ed-a964-68a312701fbe.PNG)
6) Nest hub max view
![6](https://user-images.githubusercontent.com/77922626/152306551-4f1cbf9f-a8bc-481a-abce-2d13291b410a.PNG)

