### PR TITLE
fix: remove the weird rectangle in the get in touch section #1240

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1596,7 +1596,6 @@ p {
 	color: #fff;
 	font-size: 1rem;
 	padding: 5px 20px;
-	height: 1.875em;
 	font-size: 1rem;
 	border: none;
 	outline: none;


### PR DESCRIPTION
### 🛠️ Fixes Issue

Closes #1240 

### 👨‍💻 Changes proposed

it was a pretty easy fix just remove to change the textarea's height, to remove the rectangle

### ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

- [ x] My code follows the code style of this project.
- [ x] This PR does not contain plagiarized content.
- [ x] The title of my pull request is a short description of the requested changes.

### 📷 Screenshots
| Before   |      After      | 
|----------|:-------------:|
| ![image](https://github.com/SauravMukherjee44/Aec-Library-Website/assets/72339688/6303e0ac-8725-4bca-8e5a-be2bf5919dbd) |  ![image](https://github.com/SauravMukherjee44/Aec-Library-Website/assets/72339688/0d9cf753-0a31-4b2f-a2ca-711e37e3ecb4) | 