### PR TITLE
⭐ Bug Fix: "Study Materials Button" links to "Audio Books Section" & vice versa, In resource.html

### DIFF
--- a/desktop.ini
+++ b/desktop.ini
@@ -1,2 +1,0 @@
-[.ShellClassInfo]
-LocalizedResourceName=@Aec-Library-Website,0

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,0 +1,2 @@
+[.ShellClassInfo]
+LocalizedResourceName=@Aec-Library-Website,0

--- a/resource.html
+++ b/resource.html
@@ -84,8 +84,8 @@
                 <a class="grid-item " href="#ncert">NCERT Books</a>
                 <a class="grid-item " href="#cbse_notes">CBSE Notes</a>
                 <a class="grid-item " href="#qb">Question Banks</a>
-                <a class="grid-item " href="#audio-books">Study Materials</a>
-                <a class="grid-item " href="#study">Audio Books</a>
+                <a class="grid-item " href="#audio-books">Audio Books</a>
+                <a class="grid-item " href="#study">Study Materials</a>
                 <a class="grid-item " href="#regLAN">Regional Books</a>
                 <a class="grid-item " href="#yt">Youtube Channels</a>
             </div>


### PR DESCRIPTION
## 🛠️ Fixes Issue

Fixes  #1430  by   @DefinitelyObsessed

## 👨‍💻 Changes proposed

Fixed the interchanged links between  "Study Materials Button" & "Audio Books Button"  in resource.html .

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers

### 📷 Screenshots

**Before**

|  ![OpSo#2 before-img-1](https://github.com/SauravMukherjee44/Aec-Library-Website/assets/99426520/71ddc58e-9d34-4e79-9857-d44ef7e62dad) | ![OpSo#2 before-img-2](https://github.com/SauravMukherjee44/Aec-Library-Website/assets/99426520/2a6d3f8e-5a69-440b-9217-8ef432f18a75) |
| --- | --- |


**After**

| ![OpSo#2 after-img-1](https://github.com/SauravMukherjee44/Aec-Library-Website/assets/99426520/b85d35c4-f93c-41d8-8fa4-764f6706d360) | ![OpSo#2 after-img-2](https://github.com/SauravMukherjee44/Aec-Library-Website/assets/99426520/cfc7b8dc-a400-4058-a4ac-0455244fca4e) |
| --- | --- |
