### PR TITLE
Added the mail tag to the about.html file 

### DIFF
--- a/about.html
+++ b/about.html
@@ -186,7 +186,7 @@
             </div>
             <div class="email">
               <span class="fas fa-envelope" style="color: rgb(204, 204, 204);"></span>
-              <span class="text" style="color: rgb(204, 204, 204);">contact@example.com</span>
+              <a href="mailto:contact@example.com" class="text" style="color: rgb(204, 204, 204);">contact@example.com</a>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@
 
             <h1 class="search-heading">Read Books</h2>
             <input type="text" id="myInput" onkeyup="myFunction()" placeholder="Search for names.."
-
+            
               title="Type in a name">
             <ul id="myUL">
               <li><a href="./Notes/physicselectricitynotes.pdf" target="_blank">Current Electricity Problem book</a>

--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -211,7 +211,8 @@
             <p>
                 If you have any questions or suggestions about the Privacy Policy, do not
                 hesitate to contact us by
-                email: contact@aeclibrary.com
+                <a href="mailto: contact@aeclibrary.com">email.</a> 
+                <!-- email: contact@aeclibrary.com -->
             </p>
         </div>
     </div>


### PR DESCRIPTION
### 🛠️ Fixes Issue
Issue - #1450 

### 👨‍💻 Changes proposed

Added a clickable email link to the email address on the about page in `about.html`.

In this PR, I have modified the `about.html` file to include a clickable email link for the email address provided in the "contact@example.com" span. By using the `mailto:` URL scheme, users can now click on the email address, and it will open their default email client, allowing them to compose an email to the specified address.

### ✔️ Check List (Check all the applicable boxes) 

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


