### PR TITLE
⭐ Bug Fix : In mobile width "Back to Home Button" overlap with "Search Bar" , In resource.html

### DIFF
--- a/resource.css
+++ b/resource.css
@@ -700,6 +700,7 @@ h3.hover-underline-animation {
   .search-box-container{
     display: flex;
     justify-content: center;
+    margin-top: 50px;
   }
 }
 .play-button-container:hover {


### PR DESCRIPTION
## 🛠️ Fixes Issue

Fixes  #1461  by   @DefinitelyObsessed



## 👨‍💻 Changes proposed

Fixed the overlapping of "Back to Home Button" with "Search Bar" , in mobile width, in resource.html




## ✔️ Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.



## 📷 Screenshots

| Before | After |
| --- | --- |
| ![OpSo#5 before-img](https://github.com/SauravMukherjee44/Aec-Library-Website/assets/99426520/e92d9dea-314a-4801-9567-2d5b571ea15c) | ![OpSo#5 after-img](https://github.com/SauravMukherjee44/Aec-Library-Website/assets/99426520/916dfea3-92ae-400d-b634-2eb628634414) |

