### PR TITLE
⭐Bug Fix: Entire section of the heading "AEC LIBRARY", on click links to "index.html" , in "resource.html"

### DIFF
--- a/resource.css
+++ b/resource.css
@@ -135,6 +135,11 @@ body {
   font-family: 'Roboto', sans-serif;
 }
 
+header .nav-link {
+  margin: 0 auto;
+  width: fit-content;
+}
+
 header h1 {
   text-align: center;
   font-size: 40px;

--- a/resource.css
+++ b/resource.css
@@ -135,11 +135,6 @@ body {
   font-family: 'Roboto', sans-serif;
 }
 
-header .nav-link {
-  margin: 0 auto;
-  width: fit-content;
-}
-
 header h1 {
   text-align: center;
   font-size: 40px;

--- a/resource.html
+++ b/resource.html
@@ -66,7 +66,7 @@
             </div>
             
         </div>
-      <a href="index.html" class="nav-link"> <h1>AEC Library</h1></a>
+      <a class="nav-link"> <h1>AEC Library</h1></a>
 
     
     </header>


### PR DESCRIPTION
## 🛠️ Fixes Issue

Fixes  #1469  by   @DefinitelyObsessed

## 👨‍💻 Changes proposed

In resource.html Fixed :
-  On click, only heading "AEC LIBRARY" links to "index.html" , 
- So only on hovering over heading "AEC LIBRARY",  pointer is 'cursor pointer',  instead of it's entire section, In "resource.html"


## ✔️ Check List (Check all the applicable boxes) 

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


## 📷 Screenshots

| Before | After |
| --- | --- |
|  ![OpSo#6 before-img](https://github.com/SauravMukherjee44/Aec-Library-Website/assets/99426520/ebb1829a-159b-41ff-aa63-05ba44835457) |  ![OpSo#6 after-img](https://github.com/SauravMukherjee44/Aec-Library-Website/assets/99426520/270aa7d2-5e3a-45af-835e-78a2fb7551b0) |



